### PR TITLE
Ensure to enable EBS volume encryption

### DIFF
--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -48,7 +48,11 @@ resource "aws_ebs_volume" "web_host_storage" {
     git_repo             = "terragoat"
     yor_trace            = "c5509daf-10f0-46af-9e03-41989212521d"
   })
+  # [Shisho]: The encryption will use AWS manged key. 
+  # You can specify a customer-managed key (CMK) with kms_key_id attribute.
+  encrypted = true
 }
+
 
 resource "aws_ebs_snapshot" "example_snapshot" {
   # ebs snapshot without encryption


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

An EBS volume may be unencrypted depending on settings by an `aws_ebs_encryption_by_default` resource. The volume encryption will help you protect your data from unauthorized access to the underlying device.

